### PR TITLE
depreciate/rename some enum members relating to user maps

### DIFF
--- a/src/User/Entities/OsuUser.cs
+++ b/src/User/Entities/OsuUser.cs
@@ -99,7 +99,10 @@ namespace DragonFruit.Orbit.Api.User.Entities
         [JsonProperty("loved_beatmapset_count")]
         public uint LovedMapsetCount { get; set; }
 
-        [JsonProperty("ranked_and_approved_beatmapset_count")]
+        [JsonProperty("pending_beatmapset_count")]
+        public uint PendingMapsetCount { get; set; }
+
+        [JsonProperty("ranked_beatmapset_count")]
         public uint RankedMapsetCount { get; set; }
 
         [JsonProperty("follower_count")]
@@ -179,24 +182,24 @@ namespace DragonFruit.Orbit.Api.User.Entities
         }
 
         [JsonProperty("profile_order")]
-        public IEnumerable<string> ProfileOrder { get; set; }
+        public string[] ProfileOrder { get; set; }
 
         [CanBeNull]
         [JsonProperty("badges")]
-        public IEnumerable<OsuUserBadge> Badges { get; set; }
+        public OsuUserBadge[] Badges { get; set; }
 
         [JsonProperty("user_achievements")]
-        public IEnumerable<OsuUserAchievement> Achievements { get; set; }
+        public OsuUserAchievement[] Achievements { get; set; }
 
         [CanBeNull]
         [JsonProperty("previous_usernames")]
-        public IEnumerable<string> PreviousNames { get; set; }
+        public string[] PreviousNames { get; set; }
 
         [CanBeNull]
         [JsonProperty("replays_watched_counts")]
-        public IEnumerable<OsuStatisticsPeriod<uint>> ReplayWatchCounts { get; set; }
+        public OsuStatisticsPeriod<uint>[] ReplayWatchCounts { get; set; }
 
         [JsonProperty("monthly_playcounts")]
-        public IEnumerable<OsuStatisticsPeriod<uint>> PlayCounts { get; set; }
+        public OsuStatisticsPeriod<uint>[] PlayCounts { get; set; }
     }
 }

--- a/src/User/Enums/UserBeatmapType.cs
+++ b/src/User/Enums/UserBeatmapType.cs
@@ -1,6 +1,7 @@
 ﻿// Orbit API Copyright (C) 2019-2021 DragonFruit Network
 // Licensed under the MIT License - see the LICENSE file at the root of the project for more info
 
+using System;
 using System.ComponentModel;
 using DragonFruit.Orbit.Api.Utils;
 
@@ -8,9 +9,9 @@ namespace DragonFruit.Orbit.Api.User.Enums
 {
     public enum UserBeatmapType
     {
+        Ranked,
+        Pending,
         Favourite,
-        Loved,
-        Unranked,
 
         [ExternalValue("graveyard")]
         Graveyarded,
@@ -19,8 +20,12 @@ namespace DragonFruit.Orbit.Api.User.Enums
         [ExternalValue("most_played")]
         MostPlayed,
 
+        [Obsolete("Depreciated osu-side. Use Pending instead")]
+        Unranked,
+
         [Description("Ranked and Approved")]
         [ExternalValue("ranked_and_approved")]
+        [Obsolete("Depreciated osu-side. Use Ranked instead")]
         RankedAndApproved,
     }
 }


### PR DESCRIPTION
A change PR'd today depreciates some of the enum members. Also removed one that I don't think should have existed...