### PR TITLE
Upgrade dragonfruit.common.data

### DIFF
--- a/src/Auth/Extensions/OsuClientAuthExtensions.cs
+++ b/src/Auth/Extensions/OsuClientAuthExtensions.cs
@@ -16,7 +16,7 @@ namespace DragonFruit.Orbit.Api.Auth.Extensions
         /// <param name="client">The <see cref="OrbitClient"/> to use</param>
         public static OsuAuthToken GetSessionToken<T>(this T client) where T : OrbitClient
         {
-            return client.Perform(new OsuClientAuthRequest());
+            return client.Perform<OsuAuthToken>(new OsuClientAuthRequest());
         }
     }
 }

--- a/src/Auth/Extensions/OsuClientAuthExtensions.cs
+++ b/src/Auth/Extensions/OsuClientAuthExtensions.cs
@@ -11,7 +11,7 @@ namespace DragonFruit.Orbit.Api.Auth.Extensions
         /// Use the <see cref="OrbitClient"/> credentials to create a guest user access token
         /// </summary>
         /// <remarks>
-        /// Client credentials don't give a refresh token (as it's pointless)
+        /// Client credentials don't issue refresh tokens
         /// </remarks>
         /// <param name="client">The <see cref="OrbitClient"/> to use</param>
         public static OsuAuthToken GetSessionToken<T>(this T client) where T : OrbitClient

--- a/src/Auth/Extensions/OsuUserAuthExtensions.cs
+++ b/src/Auth/Extensions/OsuUserAuthExtensions.cs
@@ -27,6 +27,11 @@ namespace DragonFruit.Orbit.Api.Auth.Extensions
         /// <param name="refreshCode">The code to exchange for the new pair</param>
         public static OsuAuthToken RefreshSession<T>(this T client, string refreshCode) where T : OrbitClient
         {
+            if (string.IsNullOrEmpty(refreshCode))
+            {
+                throw new ArgumentNullException(nameof(refreshCode));
+            }
+
             var request = new OsuUserRefreshRequest(refreshCode);
             return client.Perform<OsuAuthToken>(request);
         }
@@ -38,11 +43,6 @@ namespace DragonFruit.Orbit.Api.Auth.Extensions
         /// <param name="currentToken">The current token being used</param>
         public static OsuAuthToken RefreshSession<T>(this T client, OsuAuthToken currentToken) where T : OrbitClient
         {
-            if (string.IsNullOrEmpty(currentToken.RefreshToken))
-            {
-                throw new ArgumentNullException(nameof(currentToken.RefreshToken));
-            }
-
             return RefreshSession(client, currentToken.RefreshToken);
         }
     }

--- a/src/Auth/Extensions/OsuUserAuthExtensions.cs
+++ b/src/Auth/Extensions/OsuUserAuthExtensions.cs
@@ -17,7 +17,7 @@ namespace DragonFruit.Orbit.Api.Auth.Extensions
         public static OsuAuthToken GetSessionToken<T>(this T client, string code, string redirectUri) where T : OrbitClient
         {
             var request = new OsuUserAuthRequest(code, redirectUri);
-            return client.Perform(request);
+            return client.Perform<OsuAuthToken>(request);
         }
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace DragonFruit.Orbit.Api.Auth.Extensions
         public static OsuAuthToken RefreshSession<T>(this T client, string refreshCode) where T : OrbitClient
         {
             var request = new OsuUserRefreshRequest(refreshCode);
-            return client.Perform(request);
+            return client.Perform<OsuAuthToken>(request);
         }
 
         /// <summary>

--- a/src/Auth/Requests/OsuAuthRequest.cs
+++ b/src/Auth/Requests/OsuAuthRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Orbit API Copyright (C) 2019-2021 DragonFruit Network
 // Licensed under the MIT License - see the LICENSE file at the root of the project for more info
 
+using System;
 using DragonFruit.Common.Data;
 using DragonFruit.Common.Data.Parameters;
 
@@ -21,5 +22,14 @@ namespace DragonFruit.Orbit.Api.Auth.Requests
 
         [FormParameter("grant_type")]
         public abstract string GrantType { get; }
+
+        protected override void OnRequestExecuting(ApiClient client)
+        {
+            if (client is OrbitClient orbit)
+            {
+                ClientId ??= orbit.ClientId ?? throw new NullReferenceException($"{nameof(ClientId)} is not set.");
+                ClientSecret ??= orbit.ClientSecret ?? throw new NullReferenceException($"{nameof(ClientSecret)} is not set.");
+            }
+        }
     }
 }

--- a/src/DragonFruit.Orbit.API.csproj
+++ b/src/DragonFruit.Orbit.API.csproj
@@ -22,8 +22,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Common.Data" Version="2021.910.47" />
-        <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
+        <PackageReference Include="DragonFruit.Common.Data" Version="2021.1130.58-beta" />
+        <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Legacy/Extensions/OsuLegacyScoreExtensions.cs
+++ b/src/Legacy/Extensions/OsuLegacyScoreExtensions.cs
@@ -27,7 +27,7 @@ namespace DragonFruit.Orbit.Api.Legacy.Extensions
                 Limit = limit
             };
 
-            return client.Perform<OsuLegacyScore>(request);
+            return client.Perform<IEnumerable<OsuLegacyScore>>(request);
         }
 
         /// <summary>

--- a/src/Legacy/Extensions/OsuLegacyUserExtensions.cs
+++ b/src/Legacy/Extensions/OsuLegacyUserExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Orbit API Copyright (C) 2019-2021 DragonFruit Network
 // Licensed under the MIT License - see the LICENSE file at the root of the project for more info
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using DragonFruit.Orbit.Api.Legacy.Entities;
@@ -29,7 +30,7 @@ namespace DragonFruit.Orbit.Api.Legacy.Extensions
             };
 
             // the array should only return a single item.
-            return client.Perform<OsuLegacyUser>(request, token).SingleOrDefault();
+            return client.Perform<IEnumerable<OsuLegacyUser>>(request, token).SingleOrDefault();
         }
     }
 }

--- a/src/Legacy/Extensions/OsuLegacyUserScoreExtensions.cs
+++ b/src/Legacy/Extensions/OsuLegacyUserScoreExtensions.cs
@@ -40,7 +40,7 @@ namespace DragonFruit.Orbit.Api.Legacy.Extensions
                 IsIdentifierUsername = isIdentifierUsername
             };
 
-            return client.Perform<OsuLegacyScore>(request);
+            return client.Perform<IEnumerable<OsuLegacyScore>>(request);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace DragonFruit.Orbit.Api.Legacy.Extensions
                 IsIdentifierUsername = isIdentifierUsername
             };
 
-            return client.Perform<OsuLegacyScore>(request);
+            return client.Perform<IEnumerable<OsuLegacyScore>>(request);
         }
     }
 }

--- a/src/Legacy/Requests/OsuLegacyRequest.cs
+++ b/src/Legacy/Requests/OsuLegacyRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Orbit API Copyright (C) 2019-2021 DragonFruit Network
 // Licensed under the MIT License - see the LICENSE file at the root of the project for more info
 
+using System.Security.Authentication;
 using DragonFruit.Common.Data;
 using DragonFruit.Common.Data.Parameters;
 
@@ -14,5 +15,14 @@ namespace DragonFruit.Orbit.Api.Legacy.Requests
 
         [QueryParameter("k")]
         public string ApiKey { get; set; }
+
+        protected override void OnRequestExecuting(ApiClient client)
+        {
+            if (client is OrbitClient orbit)
+            {
+                // inject api key if we have a client
+                ApiKey = orbit.LegacyKey ?? throw new AuthenticationException($"{nameof(orbit.LegacyKey)} has no value");
+            }
+        }
     }
 }

--- a/src/OrbitClient.cs
+++ b/src/OrbitClient.cs
@@ -1,18 +1,14 @@
 ﻿// Orbit API Copyright (C) 2019-2021 DragonFruit Network
 // Licensed under the MIT License - see the LICENSE file at the root of the project for more info
 
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Security.Authentication;
-using System.Threading;
+using System.Threading.Tasks;
 using DragonFruit.Common.Data;
 using DragonFruit.Common.Data.Extensions;
 using DragonFruit.Common.Data.Serializers;
 using DragonFruit.Orbit.Api.Auth;
-using DragonFruit.Orbit.Api.Auth.Requests;
-using DragonFruit.Orbit.Api.Legacy.Requests;
+using Nito.AsyncEx;
 
 namespace DragonFruit.Orbit.Api
 {
@@ -27,7 +23,12 @@ namespace DragonFruit.Orbit.Api
         /// <remarks>
         /// Can be changed to use another server but is not recommended
         /// </remarks>
-        protected internal static string BaseEndpoint { get; protected set; } = "https://osu.ppy.sh";
+        public static string BaseEndpoint { get; set; } = "https://osu.ppy.sh";
+
+        /// <summary>
+        /// Synchronisation object for ensuring authenticated requests perform in an orderly fashion
+        /// </summary>
+        internal AsyncLock TokenLock { get; } = new AsyncLock();
 
         /// <summary>
         /// Optional flag to allow <see cref="HttpStatusCode.NotFound"/> to return null instead of an exception
@@ -37,12 +38,12 @@ namespace DragonFruit.Orbit.Api
         /// <summary>
         /// Legacy api key to use with v1 requests
         /// </summary>
-        protected virtual string LegacyKey => null;
+        protected internal virtual string LegacyKey => null;
 
         /// <summary>
         /// Client id from the osu! site, for use when requesting tokens for api access
         /// </summary>
-        protected virtual string ClientId => null;
+        protected internal virtual string ClientId => null;
 
         /// <summary>
         /// Client secret associated with the <see cref="ClientId"/>
@@ -50,7 +51,7 @@ namespace DragonFruit.Orbit.Api
         /// <remarks>
         /// You should read this in from a file, env var, etc. (just don't hard-code it)
         /// </remarks>
-        protected virtual string ClientSecret => null;
+        protected internal virtual string ClientSecret => null;
 
         /// <summary>
         /// Method for getting a valid <see cref="OsuAuthToken"/> when the previous one has expired or does not exist.
@@ -58,62 +59,27 @@ namespace DragonFruit.Orbit.Api
         protected abstract OsuAuthToken GetToken();
 
         /// <summary>
-        /// Performs a <see cref="OrbitRequest"/>, injecting the auth header and updating the <see cref="OsuAuthToken"/> if expired/nonexistant
+        /// Injects the current bearer token into the <see cref="OrbitRequest"/> provided, allowing for a refresh to occur if expired
         /// </summary>
-        public T Perform<T>(OrbitRequest request, CancellationToken token = default) where T : class
+        protected internal void PrepareRequest(OrbitRequest request)
         {
-            if (request.IncludeToken)
+            if (!request.IncludeToken)
             {
-                if (_token?.Expired != false)
+                return;
+            }
+
+            using (TokenLock.Lock())
+            {
+                if (_token == null || _token.Expired)
                 {
                     _token = GetToken();
                 }
-
-                request.WithAuthHeader($"Bearer {_token.AccessToken}");
             }
 
-            return base.Perform<T>(request, token);
+            request.WithAuthHeader($"Bearer {_token.AccessToken}");
         }
 
-        #region v1 Perform Functions
-
-        public IEnumerable<T> Perform<T>(OsuLegacyUserBasedRequest request, CancellationToken token = default) where T : class
-        {
-            return Perform<IEnumerable<T>>((OsuLegacyRequest)request, token);
-        }
-
-        public T Perform<T>(OsuLegacyRequest request, CancellationToken token = default) where T : class
-        {
-            request.ApiKey = LegacyKey ?? throw new AuthenticationException($"{nameof(LegacyKey)} has no value");
-            return base.Perform<T>(request, token);
-        }
-
-        #endregion
-
-        #region v2 Auth
-
-        /// <summary>
-        /// Performs a <see cref="OsuAuthRequest"/>, injecting the client id and key into the fields if not already filled
-        /// </summary>
-        public OsuAuthToken Perform(OsuAuthRequest request, CancellationToken token = default)
-        {
-            return Perform<OsuAuthToken>(request, token);
-        }
-
-        /// <summary>
-        /// Performs a <see cref="OsuAuthRequest"/>, injecting the client id and key into the fields if not already filled
-        /// </summary>
-        public T Perform<T>(OsuAuthRequest request, CancellationToken token = default) where T : class
-        {
-            request.ClientId ??= ClientId ?? throw new NullReferenceException($"{nameof(ClientId)} is not set.");
-            request.ClientSecret ??= ClientSecret ?? throw new NullReferenceException($"{nameof(ClientSecret)} is not set.");
-
-            return base.Perform<T>(request, token);
-        }
-
-        #endregion
-
-        protected override T ValidateAndProcess<T>(HttpResponseMessage response, HttpRequestMessage request)
+        protected override Task<T> ValidateAndProcess<T>(HttpResponseMessage response)
         {
             switch (response.StatusCode)
             {
@@ -124,7 +90,7 @@ namespace DragonFruit.Orbit.Api
                     return default;
 
                 default:
-                    return base.ValidateAndProcess<T>(response, request);
+                    return base.ValidateAndProcess<T>(response);
             }
         }
 

--- a/src/OrbitRequest.cs
+++ b/src/OrbitRequest.cs
@@ -14,5 +14,14 @@ namespace DragonFruit.Orbit.Api
 
         // RequireAuth is protected/internal so the client can't see it (so we create a redirect)
         internal bool IncludeToken => RequireAuth;
+
+        protected override void OnRequestExecuting(ApiClient client)
+        {
+            // inject bearer token if we have access otherwise this will fail at the validate stage
+            if (client is OrbitClient orbit)
+            {
+                orbit.PrepareRequest(this);
+            }
+        }
     }
 }

--- a/tests/DragonFruit.Orbit.Api.Tests.csproj
+++ b/tests/DragonFruit.Orbit.Api.Tests.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="NUnit" Version="3.13.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgrades to latest version of dragonfruit.common.data and adds updates for breaking changes introduced:

- ValidateAndProcess is now a `Task<T>` and has no `HttpRequestMessage`
- Requests now handle themselves at the request-level, not the client level
- Requests are now locked when checking for a valid token. **This might change in the future to a timer-based renewal system**
- Overriden `Perform<T>` methods have been removed to allow adding async extensions as well 

These are only breaking changes if you use the Perform<T> methods directly over the extension methods.